### PR TITLE
Correction d'un problème avec tinymce

### DIFF
--- a/View/Support/admin_ticket.ctp
+++ b/View/Support/admin_ticket.ctp
@@ -104,7 +104,7 @@ $Support = new SupportController(); ?>
                                     <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                                     <script type="text/javascript">
                                         tinymce.init({
-                                            selector: "#editor",
+                                            selector: "textarea#editor",
                                             height: 300,
                                             width: '100%',
                                             language: 'fr_FR',
@@ -136,13 +136,11 @@ $Support = new SupportController(); ?>
 </section>
 <script>
     $(document).ready(function () {
-        $('.avatar-client').one("load", function () {
-            var pseudo = $(this).attr("data-pseudo");
+		$('.avatar-client').each(function () {
+			var pseudo = $(this).attr("data-pseudo");
             var src = "<?= $this->Html->url('/'); ?>API/get_head_skin/" + pseudo + "/32";
             $(this).attr("src", src);
-        }).each(function () {
-            if (this.complete) $(this).load();
-        });
+		});
         AddTags("editor", "", "<br /><br /><hr>Cordialement,<br /><?= $user['pseudo']; ?>");
     });
 

--- a/View/Support/admin_ticket.ctp
+++ b/View/Support/admin_ticket.ctp
@@ -104,7 +104,7 @@ $Support = new SupportController(); ?>
                                     <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                                     <script type="text/javascript">
                                         tinymce.init({
-                                            selector: "textarea",
+                                            selector: "#editor",
                                             height: 300,
                                             width: '100%',
                                             language: 'fr_FR',

--- a/View/Support/admin_ticket.ctp
+++ b/View/Support/admin_ticket.ctp
@@ -136,11 +136,11 @@ $Support = new SupportController(); ?>
 </section>
 <script>
     $(document).ready(function () {
-		$('.avatar-client').each(function () {
-			var pseudo = $(this).attr("data-pseudo");
+        $('.avatar-client').each(function () {
+            var pseudo = $(this).attr("data-pseudo");
             var src = "<?= $this->Html->url('/'); ?>API/get_head_skin/" + pseudo + "/32";
             $(this).attr("src", src);
-		});
+        });
         AddTags("editor", "", "<br /><br /><hr>Cordialement,<br /><?= $user['pseudo']; ?>");
     });
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Support",
   "author": "Eywek",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "admin_menus": {
     "Support": {
       "icon": "fas fa-ticket-alt",


### PR DESCRIPTION
L'éditeur de texte était placé au mauvais endroit et le script exécuté au chargement de la page renvoyait alors une erreur.
Le texte pré-rempli n'était donc pas chargé, ainsi que les skins des joueurs.